### PR TITLE
[PE-2058] Improve load from S3 speed by using s3a instead of s3n

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.8</version>
+            <version>1.7.4</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val aws = project.in(file("aws")).dependsOn(jdbc,postgres,jdbcTest % "test-
   name := "ddf-jdbc-aws",
   pomExtra := submodulePom,
   libraryDependencies ++= Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.7.4"
+    "com.amazonaws" % "aws-java-sdk" % "1.10.8"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val aws = project.in(file("aws")).dependsOn(jdbc,postgres,jdbcTest % "test-
   name := "ddf-jdbc-aws",
   pomExtra := submodulePom,
   libraryDependencies ++= Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.10.8"
+    "com.amazonaws" % "aws-java-sdk" % "1.7.4"
   )
 )
 


### PR DESCRIPTION
Description and related tickets, documents

Replace s3n file system with s3a as it is faster and is stabilized enough in Hadoop 2.7 (https://wiki.apache.org/hadoop/AmazonS3).

Related:

https://adatao.atlassian.net/browse/PE-2058
Reviewers:

Main reviewer: @PangZhi @Huandao0812
Observers: @hai-adatao, @SeineRiver
Breaking changes & backward compatible issues

NA as s3a should be a drop in replacement for s3n.
